### PR TITLE
Add ML-KEM (Kyber) test case

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,17 @@ After compiling, run the executables directly. For example, to use `factor`:
 
 It will prompt for a number to factor and will display any factors found. Enter `0` to exit. Similarly, you can run `./factor1` after compiling `Source1.cpp`.
 
+
+## ML-KEM (Kyber) Test
+
+A small test is provided in `tests/test_mlkem.cpp` that verifies key generation,
+encapsulation, and decapsulation for the ML-KEM (Crystals-Kyber) algorithm via
+the `liboqs` library. Use the accompanying script to compile and run the test:
+
+```bash
+cd tests
+./test_mlkem.sh
+```
+
+The script requires `liboqs` and `pkg-config` to be installed. If these
+dependencies are missing, the test will fail to compile.

--- a/tests/test_mlkem.cpp
+++ b/tests/test_mlkem.cpp
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <string.h>
+#include <oqs/kem.h>
+
+int main() {
+    // Initialize the Kyber-512 KEM
+    OQS_KEM *kem = OQS_KEM_new(OQS_KEM_alg_kyber_512);
+    if (kem == NULL) {
+        fprintf(stderr, "Failed to initialize Kyber-512 KEM\n");
+        return 1;
+    }
+
+    // Allocate memory for keys and shared secrets
+    uint8_t *public_key = malloc(kem->length_public_key);
+    uint8_t *secret_key = malloc(kem->length_secret_key);
+    uint8_t *ciphertext = malloc(kem->length_ciphertext);
+    uint8_t *shared_secret_enc = malloc(kem->length_shared_secret);
+    uint8_t *shared_secret_dec = malloc(kem->length_shared_secret);
+
+    if (!public_key || !secret_key || !ciphertext || !shared_secret_enc || !shared_secret_dec) {
+        fprintf(stderr, "Memory allocation failed\n");
+        return 1;
+    }
+
+    // Generate key pair
+    if (OQS_KEM_keypair(kem, public_key, secret_key) != OQS_SUCCESS) {
+        fprintf(stderr, "Key pair generation failed\n");
+        return 1;
+    }
+
+    // Encapsulate
+    if (OQS_KEM_encaps(kem, ciphertext, shared_secret_enc, public_key) != OQS_SUCCESS) {
+        fprintf(stderr, "Encapsulation failed\n");
+        return 1;
+    }
+
+    // Decapsulate
+    if (OQS_KEM_decaps(kem, shared_secret_dec, ciphertext, secret_key) != OQS_SUCCESS) {
+        fprintf(stderr, "Decapsulation failed\n");
+        return 1;
+    }
+
+    // Check that both shared secrets match
+    if (memcmp(shared_secret_enc, shared_secret_dec, kem->length_shared_secret) != 0) {
+        fprintf(stderr, "Shared secrets do not match\n");
+        return 1;
+    }
+
+    printf("ML-KEM Kyber-512 test passed\n");
+
+    OQS_MEM_insecure_free(public_key);
+    OQS_MEM_insecure_free(secret_key);
+    OQS_MEM_insecure_free(ciphertext);
+    OQS_MEM_insecure_free(shared_secret_enc);
+    OQS_MEM_insecure_free(shared_secret_dec);
+    OQS_KEM_free(kem);
+    return 0;
+}

--- a/tests/test_mlkem.sh
+++ b/tests/test_mlkem.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_BIN="$SCRIPT_DIR/mlkem_test"
+
+if ! g++ "$SCRIPT_DIR/test_mlkem.cpp" -o "$TEST_BIN" $(pkg-config --cflags --libs liboqs 2>/dev/null); then
+  echo "Failed to compile ML-KEM test" >&2
+  exit 1
+fi
+
+if ! "$TEST_BIN"; then
+  echo "ML-KEM test failed" >&2
+  exit 1
+fi
+
+echo "ML-KEM test passed"


### PR DESCRIPTION
## Summary
- add C++ test for ML-KEM Kyber-512 using liboqs
- script to compile and run the ML-KEM test
- document new test in README

## Testing
- `tests/test_factor.sh`
- `tests/test_mlkem.sh` *(fails: missing liboqs)*

------
https://chatgpt.com/codex/tasks/task_e_68437b9e72008330aca10baa31bd5d19